### PR TITLE
Fix missing newline before appending decoy FASTA

### DIFF
--- a/script33/assembly.py
+++ b/script33/assembly.py
@@ -31,11 +31,15 @@ class assembly:
         
     def combine_fasta_files(self, fastaPath: str, decoyPath: str) -> None:
         self.logger.info(f'Combining target and decoy fasta files to {self.targetDecoyPath}')
-        with open(fastaPath, 'r') as fasta, open(decoyPath, 'r') as decoy, open(self.targetDecoyPath, 'w') as output:
-            for line in fasta:
-                output.write(line)
-            for line in decoy:
-                output.write(line)
+        with open(self.targetDecoyPath, 'w') as output:
+            with open(fastaPath, 'r') as fasta:
+                content = fasta.read()
+                output.write(content)
+                if content and not content.endswith('\n'):
+                    output.write('\n')
+            with open(decoyPath, 'r') as decoy:
+                for line in decoy:
+                    output.write(line)
         
     def intergrate_filtered_psms_with_feature(self, baseName: str) -> tuple[pd.DataFrame, pd.DataFrame]:
         self.logger.info(f'Intergrating filtered psms with feature for {baseName}')

--- a/script33/assembly.py
+++ b/script33/assembly.py
@@ -32,10 +32,14 @@ class assembly:
     def combine_fasta_files(self, fastaPath: str, decoyPath: str) -> None:
         self.logger.info(f'Combining target and decoy fasta files to {self.targetDecoyPath}')
         with open(self.targetDecoyPath, 'w') as output:
+            has_target_content = False
+            target_ends_with_newline = False
             with open(fastaPath, 'r') as fasta:
-                content = fasta.read()
-                output.write(content)
-                if content and not content.endswith('\n'):
+                for line in fasta:
+                    output.write(line)
+                    has_target_content = True
+                    target_ends_with_newline = line.endswith('\n')
+                if has_target_content and not target_ends_with_newline:
                     output.write('\n')
             with open(decoyPath, 'r') as decoy:
                 for line in decoy:


### PR DESCRIPTION
Fixes Issue #10

`combine_fasta_files` appends the decoy FASTA without ensuring the target FASTA ends with a newline. If the target FASTA has no trailing newline, the first decoy header is concatenated onto the last target sequence line.

This change inserts a newline when needed before appending the decoy file.